### PR TITLE
release: 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,4 @@ opkustomize cluster-credentials.dev.env ./k8s/apps/overlays/production/ --enable
 
 This project is licensed under the MIT License.
 See the [LICENSE](https://github.com/alexbaeza/opkustomize/raw/main/LICENSE) file for details.
+


### PR DESCRIPTION
OpKustomize is a Bash script that facilitates the injection of secrets and environment variable substitution using

1Password CLI ('op') and 'envsubst' respectively. It is a wrapper around 'kustomize build' and it is designed to be used in conjunction with Kustomize for Kubernetes configuration management.

Release as 1.0.0